### PR TITLE
コメントの修正、twitter:discriptionを削除

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "EMOJI関西弁変換" %></title>
+    <title>EMOJI関西弁変換</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
@@ -11,7 +11,7 @@
 
     <%= yield :head %>
 
-    <meta name="description" content="文章を関西弁＋絵文字に自動変換！おもしろ変換体験してみよう。" />
+    <meta name="description" content="絵文字をつけたい文章を入力フォームに。" />
 
     <meta property="og:title" content="EMOJI関西弁変換" />
     <meta property="og:type" content="website" />
@@ -22,7 +22,7 @@
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="EMOJI関西弁変換" />
-    <meta name="twitter:description" content="文章を関西弁＋絵文字に自動変換！おもしろ変換体験してみよう。" />
+
     <meta name="twitter:image" content="https://lingo-emoji.onrender.com/ogp/EMOJI.png" />
 
     <link rel="manifest" href="/manifest.json">

--- a/app/views/main/index.html.erb
+++ b/app/views/main/index.html.erb
@@ -19,7 +19,9 @@
         </a>
       </div>
       <div>
-        <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false">Tweet</a>
+      <a href="https://twitter.com/intent/tweet?url=https://lingo-emoji.onrender.com/" target="_blank" class="btn btn-dark">
+        <i class="bi bi-twitter-x"></i> Post
+      </a>
         <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
       </div>
     </div>


### PR DESCRIPTION
twitterdiscriptionを削除、二重になって表示できなくなっている可能性があるため
コメントが短くてdiscripitonnoの表示ができていない可能性もあるため、文章の長さを調整。