### PR TITLE
パスワードリセットの実装後、再デプロイ

### DIFF
--- a/db/migrate/20250915075339_create_translations.rb
+++ b/db/migrate/20250915075339_create_translations.rb
@@ -1,4 +1,4 @@
-class CreateTranslations < ActiveRecord::Migration[8.0]
+class CreateTranslations < ActiveRecord::Migration[7.2]
   def change
     create_table :translations do |t|
       t.integer :emoji

--- a/db/migrate/20250923150943_create_message_templates.rb
+++ b/db/migrate/20250923150943_create_message_templates.rb
@@ -1,4 +1,4 @@
-class CreateMessageTemplates < ActiveRecord::Migration[8.0]
+class CreateMessageTemplates < ActiveRecord::Migration[7.2]
   def change
     create_table :message_templates do |t|
       t.integer :category

--- a/db/migrate/20251004140429_create_meta_tags_list.meta_tags_railtie.rb
+++ b/db/migrate/20251004140429_create_meta_tags_list.meta_tags_railtie.rb
@@ -1,5 +1,5 @@
 # This migration comes from meta_tags_railtie (originally 20140114154410)
-class CreateMetaTagsList < ActiveRecord::Migration[7.0]
+class CreateMetaTagsList < ActiveRecord::Migration[7.2]
   def change
     create_table :meta_tags_lists do |t|
       t.string :name

--- a/db/migrate/20251011085156_create_users.rb
+++ b/db/migrate/20251011085156_create_users.rb
@@ -1,4 +1,4 @@
-class CreateUsers < ActiveRecord::Migration[8.0]
+class CreateUsers < ActiveRecord::Migration[7.2]
   def change
     create_table :users do |t|
       t.string :name, null: false # 空の状態を防ぐ

--- a/db/migrate/20251011085212_create_histories.rb
+++ b/db/migrate/20251011085212_create_histories.rb
@@ -1,4 +1,4 @@
-class CreateHistories < ActiveRecord::Migration[8.0]
+class CreateHistories < ActiveRecord::Migration[7.2]
   def change
     create_table :histories do |t|
       t.references :user, null: false, foreign_key: true

--- a/db/migrate/20251015152335_add_user_id_to_translations_v2.rb
+++ b/db/migrate/20251015152335_add_user_id_to_translations_v2.rb
@@ -1,4 +1,4 @@
-class AddUserIdToTranslationsV2 < ActiveRecord::Migration[8.0]
+class AddUserIdToTranslationsV2 < ActiveRecord::Migration[7.2]
   def change
     add_reference :translations, :user, null: false, foreign_key: true
   end

--- a/db/migrate/20251020132318_add_avatar_to_users.rb
+++ b/db/migrate/20251020132318_add_avatar_to_users.rb
@@ -1,4 +1,4 @@
-class AddAvatarToUsers < ActiveRecord::Migration[8.0]
+class AddAvatarToUsers < ActiveRecord::Migration[7.2]
   def change
     add_column :users, :avatar, :string
   end

--- a/db/migrate/20251027084709_reset_password.rb
+++ b/db/migrate/20251027084709_reset_password.rb
@@ -1,4 +1,4 @@
-class ResetPassword < ActiveRecord::Migration[8.0]
+class ResetPassword < ActiveRecord::Migration[7.2]
   def change
     add_column :users, :reset_password_token, :string, default: nil
     add_column :users, :reset_password_token_expires_at, :datetime, default: nil


### PR DESCRIPTION
マイグレーションファイルのバージョンが8.0だったため
（rails8のバージョンを使っていたがletter_opener_webがうまく利用できなかったためrails7へ変更）
→rails8対応のままだったためrails7バージョン対応に変更