### PR TITLE
sendgirdのメアド再設定

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,5 +76,5 @@ Rails.application.configure do
     authentication: :plain,
     enable_starttls_auto: true
   }
-  config.action_mailer.default_options = { from: ENV["MAIL_SENDER_ADDRESS"] }
+  config.action_mailer.default_options = { from: config.action_mailer.default_options = { from: "noreply@lingo-emoji.onrender.com" } }
 end


### PR DESCRIPTION
認証トークン切れの可能性があるためSender Authenticationを一度削除し再登録
その後、config/enviroment/production.rbのメアドをnoreplyに設定