### PR TITLE
データベース修正

### DIFF
--- a/db/migrate/20251107151301_change_translation_id_nullable_on_histories.rb
+++ b/db/migrate/20251107151301_change_translation_id_nullable_on_histories.rb
@@ -1,5 +1,7 @@
 class ChangeTranslationIdNullableOnHistories < ActiveRecord::Migration[7.2]
   def change
-    change_column_null :histories, :translation_id, true
+    unless column_exists?(:histories, :translation_id)
+      add_reference :histories, :translation, null: true, foreign_key: true
+    end
   end
 end


### PR DESCRIPTION
Change translation id nullable on historiesのマイグレーションファイルの読み込みに失敗
 translation_id が存在しないとエラーが出たため
 本番環境だけカラムがないためにエラーが起こった