### PR TITLE
mailer修正

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'EMOJI関西弁変換 <noreply@emojiapp.com>'
+  default from: "EMOJI関西弁変換 <noreply@emojiapp.com>"
   layout "mailer"
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,5 +76,5 @@ Rails.application.configure do
     authentication: :plain,
     enable_starttls_auto: true
   }
-  config.action_mailer.default_options = { from: 'EMOJI関西弁変換 <noreply@emojiapp.com>' }
+  config.action_mailer.default_options = { from: "EMOJI関西弁変換 <noreply@emojiapp.com>" }
 end


### PR DESCRIPTION
パスワード再設定時に送られてくるメールアドレスの表記が元のメールアドレスのまま表示されている
→noreply@emojiapp.comに表示されるように修正